### PR TITLE
Fügt nginx_proxy_path variable hinzu

### DIFF
--- a/pypaas/runners/nginxbackend.py
+++ b/pypaas/runners/nginxbackend.py
@@ -18,7 +18,7 @@ upstream backend_{name} {{
 """
 
 nginx_location = """
-    proxy_pass http://backend_{name};
+    proxy_pass http://backend_{name}{path};
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
     {extra_config}
@@ -55,6 +55,7 @@ class NginxBackend(SimpleProcess, NginxBase):
     def nginx_location(self):
         return nginx_location.format(
             name=self.name,
+            path=self.branch.config['runners'][self._name].get('nginx_proxy_path', ''),
             extra_config=self.branch.config['runners'][self._name]
                              .get('nginx_extra_config', '')
         )


### PR DESCRIPTION
Erlaubt es der `proxy_pass` Direktive einen Pfad hinten anzuängen, wodurch auch ein andere Pfad als der ursprünglich Aufrufpfad an den Upstream-Server weitergegeben kann. Dieser muss entweder leer sein oder mit einem `/` beginnen.

Siehe dazu auch folgenden Ausschnitt aus der [nginx Dokumentation](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass): 
```
If the proxy_pass directive is specified with a URI, then when a request is passed to the server, the part of a normalized request URI matching the location is replaced by a URI specified in the directive.
```